### PR TITLE
Second undici patch to be more targeted

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -4,3 +4,4 @@ README.md
 LICENSE
 src/terraform
 src/core/fetcher/getFetchFn.ts
+tests/unit/fetcher/stream-wrappers/webpack.test.ts

--- a/.fernignore
+++ b/.fernignore
@@ -3,5 +3,4 @@
 README.md
 LICENSE
 src/terraform
-src/index.ts
-tests/unit/fetcher/stream-wrappers/webpack.test.ts
+src/core/fetcher/getFetchFn.ts

--- a/src/core/fetcher/getFetchFn.ts
+++ b/src/core/fetcher/getFetchFn.ts
@@ -6,6 +6,16 @@ import { RUNTIME } from "../runtime";
 export async function getFetchFn(): Promise<any> {
     // In Node.js 18+ environments, use native fetch
     if (RUNTIME.type === "node" && RUNTIME.parsedVersion != null && RUNTIME.parsedVersion >= 18) {
+        const { setGlobalDispatcher, Agent } = await import("undici");
+
+        setGlobalDispatcher(
+            new Agent({
+                connect: { timeout: 60_000 },
+                bodyTimeout: 0,
+                headersTimeout: 600_000,
+            }),
+        );
+
         return fetch;
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,12 +3,3 @@ export { VellumClient } from "./Client";
 export { VellumEnvironment, VellumEnvironmentUrls } from "./environments";
 export { VellumError, VellumTimeoutError } from "./errors";
 export * as serialization from "./serialization";
-import { setGlobalDispatcher, Agent } from "undici";
-
-setGlobalDispatcher(
-    new Agent({
-        connect: { timeout: 60_000 },
-        bodyTimeout: 0,
-        headersTimeout: 600_000,
-    })
-);

--- a/tests/unit/fetcher/stream-wrappers/webpack.test.ts
+++ b/tests/unit/fetcher/stream-wrappers/webpack.test.ts
@@ -1,7 +1,7 @@
 import webpack from "webpack";
 
 describe("test env compatibility", () => {
-    test("webpack", () => {
+    test.skip("webpack", () => {
         return new Promise<void>((resolve, reject) => {
             webpack(
                 {

--- a/tests/unit/fetcher/stream-wrappers/webpack.test.ts
+++ b/tests/unit/fetcher/stream-wrappers/webpack.test.ts
@@ -1,7 +1,7 @@
 import webpack from "webpack";
 
 describe("test env compatibility", () => {
-    test.skip("webpack", () => {
+    test("webpack", () => {
         return new Promise<void>((resolve, reject) => {
             webpack(
                 {


### PR DESCRIPTION
Context:
<img width="1240" alt="Screenshot 2025-03-10 at 2 40 39 PM" src="https://github.com/user-attachments/assets/416f4cc6-980a-4d00-b674-1df0a11c3be6" />

In case the screenshot doesn't load, we move our undici patch to a more targeted location so that it's not dependent on how the user imports the client